### PR TITLE
Improve parsing of test results for erroring test, added duration to the test results summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ This is an early release of the extension. Issues can be reported [here]()
 ### 0.1.0
 Initial release of the extension to the public.
 ### 0.1.1
-Bug fix related to stored procedures being tested that string data that cannot be parsed as XML test output.
+Bug fix: For stored procedures that output data, fix the parser so that the tSQLt result information is what is parsed for test results.
+New: The test execution summary is now in table format. It also includes the Duration (ms) of the executed test. This looks similar to the output when running a tSQLt test directly in SSMS.
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ This extension enables you to run [tSQLt](https://github.com/tSQLt-org/tSQLt) un
 ## Getting started
 
 - Install the extension.
-- Configure Visual Studio Code to connect to a database where your source code with tSQLt extension is installed. See configuration section for more details. 
+- Configure Visual Studio Code to connect to a database where your source code with tSQLt extension is installed. See configuration section for more details.
 - In the sidebar, open the Test View and wait for the extension to discover your tests.
-- When the tests are disovered you can run them using the play button. 
+- When the tests are discovered you can run them using the play button.
 
 ## Features
 
 ### Inspecting test result
 
-The result of a test run can be inspected by clicking on any given test.  
+The result of a test run can be inspected by clicking on any given test.
 
 ![feature_test_result](images/feature_test_result.png)
 
 ## Requirements
 
-To discover and running unit tests, the extension requires a running database with the tSQLt framework installed. 
+To discover and running unit tests, the extension requires a running database with the tSQLt framework installed.
 
 There are numerous posts online that describes how to setup your database project with tSQLt as a testing framework, and how to include it in your workflow.
 
@@ -59,16 +59,15 @@ This extension contributes to the following settings and are required for discov
 ## Known Issues
 
 - Missing tSQLt framework discovery, will most likely thrown an error about SQL statements failing.
-- SQL logins are the only tested authenctiation method.
+- SQL logins are the only tested authentication method.
 - Cancellation of tests that are running is currently not supported.
 
 This is an early release of the extension. Issues can be reported [here]()
 
 ## Release Notes
 
-Users appreciate release notes as you update your extension.
-
 ### 0.1.0
-
-Initial release of the extension to the public. 
+Initial release of the extension to the public.
+### 0.1.1
+Bug fix related to stored procedures being tested that string data that cannot be parsed as XML test output.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "vscode-tsqlt-test-adapter",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "name": "vscode-tsqlt-test-adapter",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/tedious": "^4.0.3",
         "@types/xml2js": "0.4.8",
+        "cli-table": "^0.3.11",
         "tedious": "^11.0.1",
         "tslib": "^1.9.3",
         "vscode-test-adapter-api": "^1.7.0",
@@ -20,7 +22,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",
         "@types/node": "^12.11.7",
-        "@types/vscode": "^1.53.0",
+        "@types/vscode": "^1.52.1",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
         "eslint": "^7.19.0",
@@ -30,7 +32,7 @@
         "vscode-test": "^1.5.0"
       },
       "engines": {
-        "vscode": "^1.53.0"
+        "vscode": "^1.52.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -973,7 +975,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -985,6 +986,17 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
       }
     },
     "node_modules/cliui": {
@@ -1015,6 +1027,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4163,6 +4183,14 @@
         "readdirp": "~3.5.0"
       }
     },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -4188,6 +4216,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/niktho/vscode-tsqlt-test-adapter.git"
   },
   "icon": "images/icon.png",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "preview": true,
   "license": "MIT",
   "engines": {
@@ -49,6 +49,7 @@
   "dependencies": {
     "@types/tedious": "^4.0.3",
     "@types/xml2js": "0.4.8",
+    "cli-table": "^0.3.11",
     "tedious": "^11.0.1",
     "tslib": "^1.9.3",
     "vscode-test-adapter-api": "^1.7.0",

--- a/src/tSQLt/tSQLtTests.ts
+++ b/src/tSQLt/tSQLtTests.ts
@@ -76,14 +76,10 @@ export class tSQLtTestRunner {
             result['value'],
             { explicitArray: false, explicitRoot: false, mergeAttrs: true },
             (err, result) => {
-                if (err) {
-                    this.fireTestEvent(nodeId, 'errored', err.message);
+                if (result?.testsuite.failures > 0) {
+                    this.fireTestEvent(nodeId, 'failed', result.testsuite.testcase.failure.message);
                 } else {
-                    if (result.testsuite.failures > 0) {
-                        this.fireTestEvent(nodeId, 'failed', result.testsuite.testcase.failure.message);
-                    } else {
-                        this.fireTestEvent(nodeId, 'passed');
-                    }
+                    this.fireTestEvent(nodeId, 'passed');
                 }
             });
     }
@@ -104,7 +100,7 @@ export class tSQLtTestRunner {
         node: TestSuiteInfo | TestInfo,
     ): Promise<void> {
         var query = `
-        exec [tSQLt].[Run] '${node.id}', 'tSQLt.XmlResultFormatter';        
+        EXEC [tSQLt].[Run] '${node.id}', 'tSQLt.XmlResultFormatter';
         `;
 
         if (node.type === 'suite') {
@@ -134,12 +130,12 @@ export class tSQLtTestRunner {
     private async getTestCasesForTestClass(schemaId: number): Promise<TestInfo[]> {
         var testInfos: TestInfo[] = [];
         var query = `
-        SELECT 
-            [SchemaId], 
-            [TestClassName], 
-            [ObjectId], 
-            [Name] 
-        FROM [tSQLt].[Tests] 
+        SELECT
+            [SchemaId],
+            [TestClassName],
+            [ObjectId],
+            [Name]
+        FROM [tSQLt].[Tests]
         WHERE [SchemaId] = ${schemaId};
         `;
 
@@ -163,9 +159,9 @@ export class tSQLtTestRunner {
     private async getTestClasses(): Promise<TestSuiteInfo[]> {
         var testSuites: TestSuiteInfo[] = [];
         var query = `
-        SELECT 
-            [Name], 
-            [SchemaId] 
+        SELECT
+            [Name],
+            [SchemaId]
         FROM [tSQLt].[TestClasses];
         `;
 


### PR DESCRIPTION
- Parsing the results of a test is improved, where we find the correct `<testsuites>` piece of the output. This handles issue https://github.com/niktho/vscode-tsqlt-test-adapter/issues/2#issue-1622130359. It actually also handles tests that are throwing unexpected exceptions. The exception output was not resulting in a failed test, now it will
- Improve output of test results: adding duration and table formatting

Here is an example of the new output format.
![image](https://user-images.githubusercontent.com/10524529/227579974-e95c19c1-6e2c-41a1-aa7f-03f5c4b39236.png)
